### PR TITLE
#11 Feature request: Specifying files rather than a directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Or for Gradle 2.1+:
 
 ```groovy
 plugins {
-	id "org.jruyi.thrift" version "0.3.2"
+	id "org.jruyi.thrift" version "0.3.3"
 }
 ```
 
@@ -49,6 +49,7 @@ Task Property     | Type                | Default Value
 ------------------|---------------------|---------------------------------------------------
 thriftExecutable  | String              | thrift
 sourceDir         | File                | src/main/thrift
+sourceItems       | Object...           | src/main/thrift
 outputDir         | File                | _buildDir_/generated-sources/thrift
 includeDirs       | Set<File>           | []
 generators        | Map<String, String> | ['java':''] if JavaPlugin is applied, otherwise []
@@ -62,6 +63,12 @@ allow64bitsConsts | boolean             | false
 createGenFolder   | boolean             | true
 
 If createGenFolder is set to false, no gen-* folder will be created.
+
+sourceDir is only used for backward compatibility
+
+sourceItems are a set of sources, which will be used for generating java files from thrift.
+A source can either be a path specified as a string or a file. In case a source is a relative path the source will be relative to _srcDir_. 
+In case a source is a directory, the directory will be scanned recursively for *.thrift files and used.   
 
 ##### Example
 

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ apply plugin: 'maven-publish'
 
 group = 'org.jruyi.gradle'
 archivesBaseName = 'thrift-gradle-plugin'
-version = '0.3.2'
+version = '0.3.3'
 description = 'A gradle plugin for compiling Thrift IDL files using thrift compiler'
 
 ext {


### PR DESCRIPTION
I've attempted a while ago to implement a solution to the feature that I requested, but did not have the time to make a pull request.

The feature kind of deprecates sourceDir and adds a new method sourceItems, which may take strings or files, where each item is a location to a .thrift file or a directory containing .thrift files

Just as a note @pamalyshev made a similar solution but a little bit different in respect to support for string and files