### PR TITLE
Doesn't work with java 11

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 
 /build
 /test/build
+/examples/*/build/

--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ The Thrift plugin adds compileThrift task which compiles Thrift IDL files using 
 Task Property     | Type                | Default Value
 ------------------|---------------------|---------------------------------------------------
 thriftExecutable  | String              | thrift
-sourceDir         | File                | src/main/thrift
-sourceItems       | Object...           | src/main/thrift
+sourceDir         | File                | _projectDir_/src/main/thrift
+sourceItems       | Object...           | _projectDir_/src/main/thrift
 outputDir         | File                | _buildDir_/generated-sources/thrift
 includeDirs       | Set<File>           | []
 generators        | Map<String, String> | ['java':''] if JavaPlugin is applied, otherwise []

--- a/examples/test1/build.gradle
+++ b/examples/test1/build.gradle
@@ -26,7 +26,7 @@ apply plugin: 'org.jruyi.thrift'
 
 group = 'org.jruyi.gradle'
 archivesBaseName = 'thrift-gradle-plugin-test'
-version = '0.3.1'
+version = '0.4.0'
 description = 'Test thrift-gradle-plugin'
 
 ext {
@@ -56,7 +56,7 @@ dependencies {
 
 compileThrift {
 	thriftExecutable "thrift"
-	sourceDir "src/main/thrift"
+	sourceDir "$projectDir/src/main/thrift"
 	outputDir "$buildDir/gen-src"
 
 	nowarn true

--- a/examples/test2/build.gradle
+++ b/examples/test2/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id "org.jruyi.thrift" version "0.3.1"
+  id "org.jruyi.thrift" version "0.4.0"
 }
 
 apply plugin: 'java'

--- a/src/main/groovy/org/jruyi/gradle/thrift/plugin/ThriftPlugin.groovy
+++ b/src/main/groovy/org/jruyi/gradle/thrift/plugin/ThriftPlugin.groovy
@@ -24,7 +24,7 @@ class ThriftPlugin implements Plugin<Project> {
 	@Override
 	void apply(Project project) {
 
-		def srcDir = 'src/main/thrift'
+		def srcDir = "${project.projectDir}/src/main/thrift"
 		def dstDir = "${project.buildDir}/generated-sources/thrift"
 
 		CompileThrift compileThrift = project.tasks.create(COMPILE_THRIFT_TASK, CompileThrift)


### PR DESCRIPTION
Hello.
In my sandbox app, this plugin doesn't work with java 11.
I'm guessing `thrift-gradle-plugin` can't find thrift IDL files.

my sandbox app:
https://github.com/matsumana/armeria-sandbox/tree/thrift-compil-error-with-jdk11

I tried the following setting in `compileThrift` with my app's build.gradle, it worked fine.

`sourceDir "${projectDir}/src/main/thrift"`

---

Using Java version:

Java 11 build 28

```
$ java -version
openjdk version "11" 2018-09-25
OpenJDK Runtime Environment 18.9 (build 11+28)
OpenJDK 64-Bit Server VM 18.9 (build 11+28, mixed mode)
```