### PR TITLE
The default value of sourceItems is not overwritten

### DIFF
--- a/src/main/groovy/org/jruyi/gradle/thrift/plugin/CompileThrift.groovy
+++ b/src/main/groovy/org/jruyi/gradle/thrift/plugin/CompileThrift.groovy
@@ -67,6 +67,7 @@ class CompileThrift extends DefaultTask {
 	}
 
 	def sourceItems(Object... sourceItems) {
+		this.sourceItems.clear()
 		sourceItems.each { sourceItem ->
 			this.sourceItems.add(convertToFile(sourceItem))
 		}


### PR DESCRIPTION
Hello. I am using the latest version, but if I set `sourceDir` or `sourceItems`, the following warn log will be output.
It looks like the default value remains in `sourceItems`.

```
> Task :compileThrift
Could not find MyProjectDir/src/main/thrift. Will ignore it
```
