### PR TITLE
Fix deprecation warnings from Gradle 6.0

### DIFF
--- a/examples/test1/build.gradle
+++ b/examples/test1/build.gradle
@@ -52,6 +52,7 @@ repositories {
 dependencies {
 	compile "org.slf4j:slf4j-api:1.7.20"
 	compile "org.apache.thrift:libthrift:0.9.3"
+	compile "javax.annotation:javax.annotation-api:1.3.2"
 }
 
 compileThrift {

--- a/examples/test2/build.gradle
+++ b/examples/test2/build.gradle
@@ -10,4 +10,5 @@ repositories {
 
 dependencies {
   compile group: 'org.apache.thrift', name: 'libthrift', version: '0.9.3'
+  compile "javax.annotation:javax.annotation-api:1.3.2"
 }

--- a/src/main/groovy/org/jruyi/gradle/thrift/plugin/CompileThrift.groovy
+++ b/src/main/groovy/org/jruyi/gradle/thrift/plugin/CompileThrift.groovy
@@ -20,6 +20,7 @@ import org.gradle.api.Task
 import org.gradle.api.plugins.JavaPlugin
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.incremental.IncrementalTaskInputs
@@ -53,9 +54,16 @@ class CompileThrift extends DefaultTask {
 	@Input
 	boolean allow64bitsConsts
 
+	@Internal
 	boolean nowarn
+
+	@Internal
 	boolean strict
+
+	@Internal
 	boolean verbose
+
+	@Internal
 	boolean debug
 
 	def thriftExecutable(Object thriftExecutable) {


### PR DESCRIPTION
Annotates properties `nowarn`, `strict`, `verbose`, and `debug` with `@Internal` since none of these should be taken into account for up-to-date checking. See https://docs.gradle.org/6.0/javadoc/org/gradle/api/tasks/Internal.html for more details.

See #25.