### PR TITLE
NON-ISSUE Cleanup gradle legacy usage which will be removed in 7.0

### DIFF
--- a/src/main/groovy/org/jruyi/gradle/thrift/plugin/CompileThrift.groovy
+++ b/src/main/groovy/org/jruyi/gradle/thrift/plugin/CompileThrift.groovy
@@ -53,9 +53,16 @@ class CompileThrift extends DefaultTask {
 	@Input
 	boolean allow64bitsConsts
 
+	@Input
 	boolean nowarn
+
+	@Input
 	boolean strict
+
+	@Input
 	boolean verbose
+
+	@Input
 	boolean debug
 
 	def thriftExecutable(Object thriftExecutable) {


### PR DESCRIPTION
Hello. Thank you publishing to great plugin. I use it very well.

Recently, I noticed the following warnings. Let me fix it. Thank you!

Ref https://docs.gradle.org/6.7-rc-2/userguide/more_about_tasks.html#sec:up_to_date_checks

```
Property 'debug' is not annotated with an input or output annotation. This behaviour has been deprecated and is scheduled to be removed in Gradle 7.0. See https://docs.gradle.org/6.7-rc-2/userguide/more_about_tasks.html#sec:up_to_date_checks for more details.
Property 'nowarn' is not annotated with an input or output annotation. This behaviour has been deprecated and is scheduled to be removed in Gradle 7.0. See https://docs.gradle.org/6.7-rc-2/userguide/more_about_tasks.html#sec:up_to_date_checks for more details.
Property 'strict' is not annotated with an input or output annotation. This behaviour has been deprecated and is scheduled to be removed in Gradle 7.0. See https://docs.gradle.org/6.7-rc-2/userguide/more_about_tasks.html#sec:up_to_date_checks for more details.
Property 'verbose' is not annotated with an input or output annotation. This behaviour has been deprecated and is scheduled to be removed in Gradle 7.0. See https://docs.gradle.org/6.7-rc-2/userguide/more_about_tasks.html#sec:up_to_date_checks for more details.
```